### PR TITLE
Add a BDD test job for jiva in OpenEBS-base pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,6 +42,13 @@ BDD:
   script:
     - chmod 775 ./Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/BDD/cstor-integration-test
     - ./Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/BDD/cstor-integration-test
+
+BDD-jiva:
+  image: openebs/openshift-ci:latest
+  stage: OPENEBS-SETUP
+  script:
+    - chmod 775 ./Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/BDD/jiva/bdd-jiva
+    - ./Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/BDD/jiva/bdd-jiva
     
 .func_test_template:
   image: openebs/openshift-ci:latest

--- a/Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/BDD/Jiva/bdd-jiva
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/BDD/Jiva/bdd-jiva
@@ -33,10 +33,8 @@ cd /home/devuser/go/src/github.com/openebs
 
 git clone https://github.com/openebs/maya.git
 
-cd maya/tests/jiva/clone
-
 # Running BDD test for jiva-clone
-ginkgo -v -- -kubeconfig=~/.kube/config
+cd maya/tests/jiva/clone && ginkgo -v -- -kubeconfig=~/.kube/config
 
 #Evaluating result based on the return count
 
@@ -54,7 +52,7 @@ else
 fi
 
 # Running BDD test for jiva-node-stickiness
-cd /home/devuser/go/src/github.com/openebsmaya/tests/jiva/node-stickiness
+cd /home/devuser/go/src/github.com/openebs/maya/tests/jiva/node-stickiness
 ginkgo -v -- -kubeconfig=~/.kube/config
 
 #Evaluating result based on the return count
@@ -73,7 +71,7 @@ else
 fi
 
 # Running BDD test for jiva-snapshot
-cd /home/devuser/go/src/github.com/openebsmaya/tests/jiva/snapshot
+cd /home/devuser/go/src/github.com/openebs/maya/tests/jiva/snapshot
 ginkgo -v -- -kubeconfig=~/.kube/config
 
 #Evaluating result based on the return count
@@ -92,7 +90,7 @@ else
 fi
 
 # Running BDD test for jiva-volume
-cd /home/devuser/go/src/github.com/openebsmaya/tests/jiva/volume
+cd /home/devuser/go/src/github.com/openebs/maya/tests/jiva/volume
 ginkgo -v -- -kubeconfig=~/.kube/config
 
 #Evaluating result based on the return count

--- a/Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/BDD/Jiva/bdd-jiva
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/BDD/Jiva/bdd-jiva
@@ -1,0 +1,119 @@
+#!/bin/bash
+set -x
+pod() {
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-openshift && bash Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/BDD/jiva/bdd-jiva node '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"'
+}
+
+node() {
+
+job_id=$(echo $1) #Gitlab job id obtain from the gitlab env ($CI_JOB_ID).
+pipeline_id=$(echo $2)  # Gitlab pipeline id obtained from gitlab env ($CI_PIPELINE_ID).
+case_id=HC5P          # This need to be changed
+commit_id=$(echo $3) #Gitlab commit id Obtained fron gilab env ($CI_COMMIT_SHA).
+
+source ~/.profile
+
+#github token to push the test result into github mayadata-io/e2e-openshift repository.
+#This token is set as an env in ~/.profile in the test cluster.
+
+gittoken=$(echo "$github_token")
+
+time="date"
+current_time=$(eval $time)
+
+#pooling over previous job to complete
+bash Openshift-EE/utils/pooling jobname:s2-j1-openebs-deploy
+bash Openshift-EE/utils/e2e-cr jobname:BDD-Jiva jobphase:Waiting
+
+# Update the e2e event for the job.
+bash Openshift-EE/utils/e2e-cr jobname:BDD-Jiva jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+#cloneing openebs/maya repo
+cd /home/devuser/go/src/github.com/openebs
+
+git clone https://github.com/openebs/maya.git
+
+cd maya/tests/jiva/clone
+
+# Running BDD test for jiva-clone
+ginkgo -v -- -kubeconfig=~/.kube/config
+
+#Evaluating result based on the return count
+
+if [ "$?" != "0" ];then
+  echo "jiva-clone-test-failed"
+  current_time=$(eval $time)
+  cd /home/devuser/e2e-openshift
+  bash Openshift-EE/utils/e2e-cr jobname:cstor-integration-test jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Fail
+  exit 1;
+else
+  echo "jivs-clone-test-passed"
+  current_time=$(eval $time)
+  cd /home/devuser/e2e-openshift
+  bash Openshift-EE/utils/e2e-cr jobname:cstor-integration-test jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Pass
+fi
+
+# Running BDD test for jiva-node-stickiness
+cd /home/devuser/go/src/github.com/openebsmaya/tests/jiva/node-stickiness
+ginkgo -v -- -kubeconfig=~/.kube/config
+
+#Evaluating result based on the return count
+
+if [ "$?" != "0" ];then
+  echo "jiva-node-stickiness-test-failed"
+  current_time=$(eval $time)
+  cd /home/devuser/e2e-openshift
+  bash Openshift-EE/utils/e2e-cr jobname:cstor-integration-test jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Fail
+  exit 1;
+else
+  echo "jivs-node-stickiness-test-passed"
+  current_time=$(eval $time)
+  cd /home/devuser/e2e-openshift
+  bash Openshift-EE/utils/e2e-cr jobname:cstor-integration-test jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Pass
+fi
+
+# Running BDD test for jiva-snapshot
+cd /home/devuser/go/src/github.com/openebsmaya/tests/jiva/snapshot
+ginkgo -v -- -kubeconfig=~/.kube/config
+
+#Evaluating result based on the return count
+
+if [ "$?" != "0" ];then
+  echo "jiva-snapshot-test-failed"
+  current_time=$(eval $time)
+  cd /home/devuser/e2e-openshift
+  bash Openshift-EE/utils/e2e-cr jobname:cstor-integration-test jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Fail
+  exit 1;
+else
+  echo "jiva-snapshot-test-passed"
+  current_time=$(eval $time)
+  cd /home/devuser/e2e-openshift
+  bash Openshift-EE/utils/e2e-cr jobname:cstor-integration-test jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Pass
+fi
+
+# Running BDD test for jiva-volume
+cd /home/devuser/go/src/github.com/openebsmaya/tests/jiva/volume
+ginkgo -v -- -kubeconfig=~/.kube/config
+
+#Evaluating result based on the return count
+
+if [ "$?" != "0" ];then
+  echo "jiva-volume-test-failed"
+  current_time=$(eval $time)
+  cd /home/devuser/e2e-openshift
+  bash Openshift-EE/utils/e2e-cr jobname:cstor-integration-test jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Fail
+  exit 1;
+else
+  echo "jiva-volume-test-passed"
+  current_time=$(eval $time)
+  cd /home/devuser/e2e-openshift
+  bash Openshift-EE/utils/e2e-cr jobname:cstor-integration-test jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Pass
+fi
+
+}
+
+if [ "$1" == "node" ];then
+  node $2 $3 $4
+else
+  pod
+fi

--- a/Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/BDD/cstor-integration-test
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/BDD/cstor-integration-test
@@ -26,7 +26,7 @@ git clone https://github.com/openebs/maya.git
 
 cd maya/tests/cstor-pool/
 
-ginkgo -v
+ginkgo -v -- -kubeconfig=~/.kube/config
 
 if [ "$?" != "0" ];then
   echo "test-failed"


### PR DESCRIPTION
- Add bdd-test job into the ci-pipeline.
- Add script `bdd-jiva` which executes the BDD test for jiva volume,snapshot,node-stickiness & clone.