### PR TITLE
Fixed some gitlab scripts issues

### DIFF
--- a/Openshift-EE/pipelines/OpenEBS-base/stages/3-functional/4Q90-Jiva-pods-openebs-namespace/jiva-pods-openebs-ns
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/3-functional/4Q90-Jiva-pods-openebs-namespace/jiva-pods-openebs-ns
@@ -52,7 +52,6 @@ cp apps/busybox/deployers/run_litmus_test.yml deploy_busybox_jiva_openebs.yml
  | Litmus job label  | label  | app: busybox-litmus                 | app: deploy-busybox-jiva-openebs                |
  | Litmus Job name   | name   | generateName: litmus-busybox-deploy | generateName: busybox-provision-jiva-openebs    |
  | appLabel          | env    | app=busybox-sts                     | app=busybox-jiva-openebs                        |
- | deploy type       | env    | statefulset                         | deployment                                      |
  | ImagePullPolicy   | value  | Always                              | IfNotPresent                                    |
  | pvcName           | env    | openebs-busybox                     | busybox-jiva-openebs                            | 
  | storage clas      | env    | openebs-cstor-sparse                | jiva-openebs-ns                                 |
@@ -63,7 +62,6 @@ EOF
 sed -i -e 's/app: busybox-litmus/app: deploy-busybox-jiva-openebs/g' \
 -e 's/generateName: litmus-busybox-deploy/generateName: busybox-provision-jiva-openebs/g' \
 -e 's/app=busybox-sts/app=busybox-jiva-openebs/g' \
--e 's/value: statefulset/value: deployment/g' \
 -e 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' \
 -e 's/value: openebs-busybox/value: busybox-jiva-openebs/g' \
 -e 's/value: openebs-cstor-sparse/value: jiva-openebs-ns/g' \
@@ -252,7 +250,6 @@ cp apps/busybox/deployers/run_litmus_test.yml deprovision_busybox_jiva_openebs.y
  | Litmus job label  | label  | app: busybox-litmus                 | app: deprovision-jiva-openebs                    |
  | Litmus Job name   | name   | generateName: litmus-busybox-deploy | generateName: busybox-deprovision-jiva-openebs   |
  | appLabel          | env    | app=busybox-sts                     | app=busybox-jiva-openebs                         |
- | deploy type       | env    | statefulset                         | deployment                                       |
  | action            | env    | provision                           | deprovision                                      |
  | ImagePullPolicy   | value  | Always                              | IfNotPresent                                     |
  | pvcName           | env    | openebs-busybox                     | busybox-jiva-openebs                             | 
@@ -264,7 +261,6 @@ EOF
 sed -i -e 's/app: busybox-litmus/app: deprovision-busybox-jiva-openebs/g' \
 -e 's/generateName: litmus-busybox-deploy/generateName: busybox-deprovision-jiva-openebs/g' \
 -e 's/app=busybox-sts/app=busybox-jiva-openebs/g' \
--e 's/value: statefulset/value: deployment/g' \
 -e 's/value: provision/value: deprovision/g' \
 -e 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' \
 -e 's/value: openebs-busybox/value: busybox-jiva-openebs/g' \

--- a/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/PX1D-jiva-replica-node-affinity/replica-node-affinity
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/PX1D-jiva-replica-node-affinity/replica-node-affinity
@@ -146,8 +146,8 @@ cp experiments/chaos/replica_node_affinity/run_litmus_test.yml run_rep_node_affi
 EOF
 
 sed -i -e 's/app=pgset/app=busybox-rep-node-affinity-jiva/g' \
--e 's/value: app-pgres-ns/value: rep-node-affinity-jiva/g' \
--e 's/value: pgdata-claim/value: openebs-busybox-rep-affinity/g' run_rep_node_affinity_jiva.yml
+-e 's/value: '\''app-pgres-ns'\''/value: '\''rep-node-affinity-jiva'\''/g' \
+-e 's/value: '\''pgdata-claim'\''/value: '\''openebs-busybox-rep-affinity'\''/g' run_rep_node_affinity_jiva.yml
 
 sed -i '/command:/i \
           - name: RUN_ID\
@@ -168,10 +168,6 @@ if [ "$?" != "0" ]; then
 python3 Openshift-EE/utils/result/result_update.py $job_id PX1D 4-chaos "Jiva replica node affinity" Fail $pipeline_id "$current_time" $commit_id $gittoken
 exit 1;
 fi
-
-test_name=$(bash Openshift-EE/utils/generate_test_name testcase= busybox-deprovision-rep-node-affinity-jiva metadata="")
-echo $test_name
-
 
 ################
 # LitmusBook 4 #
@@ -226,6 +222,9 @@ fi
 ################
 # LitmusBook 5 #
 ################
+
+test_name=$(bash Openshift-EE/utils/generate_test_name testcase= busybox-deprovision-rep-node-affinity-jiva metadata="")
+echo $test_name
 
 cd litmus
 # copy the content of deployer run_litmus_test.yml into a different file to update the test specific parameters.

--- a/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/TSXL-Jiva-controller-network-delay/controller-network-delay
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/TSXL-Jiva-controller-network-delay/controller-network-delay
@@ -168,14 +168,6 @@ python3 Openshift-EE/utils/result/result_update.py $job_id TSXL 4-chaos "Induce 
 exit 1;
 fi
 
-echo "********Deprovisioning Busybox Application*******"
-
-test_name=$(bash Openshift-EE/utils/generate_test_name testcase=busybox-deprovision-controller-delay-jiva metadata="")
-echo $test_name
-
-cd litmus
-cp apps/busybox/deployers/run_litmus_test.yml deprovision_controller_delay_jiva.yml
-
 ################
 # LitmusBook 4 #
 ################
@@ -230,6 +222,13 @@ fi
 ################
 # LitmusBook 5 #
 ################
+
+echo "********Deprovisioning Busybox Application*******"
+
+test_name=$(bash Openshift-EE/utils/generate_test_name testcase=busybox-deprovision-controller-delay-jiva metadata="")
+echo $test_name
+cd litmus
+cp apps/busybox/deployers/run_litmus_test.yml deprovision_controller_delay_jiva.yml
 
 : << EOF
   --------------------------------------------------------------------------------------------------------------------     


### PR DESCRIPTION
Fixed following  gitlab scripts issues:
  - OpenEBS-base/stages/4-chaos/PX1D-jiva-replica-node-affinity/replica-node-affinity: Correctly placed 
    some misplaced commands and corrected the sed operation in litmus job 3
  - Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/TSXL-Jiva-controller-network-delay/controller- 
    network-delay: Correctly placed some misplaced commands
  - OpenEBS-base/stages/3-functional/4Q90-Jiva-pods-openebs-namespace/jiva-pods-openebs-ns : 
    Deployed busybox as statefulset instead of deployment


@nsathyaseelan 