### PR TITLE
Refactored the script litmus_job_runner to get the name of litmus pod 

### DIFF
--- a/Openshift-EE/utils/litmus_job_runner
+++ b/Openshift-EE/utils/litmus_job_runner
@@ -29,17 +29,14 @@ while true; do
   litmus_pod=$(eval ${litmusPodCmd}); rc=$?
   if [[ $rc -eq 0 ]]; then
     if [[ -z ${litmus_pod} ]]; then   # if pod is not found it returns null. If pod name is not got sleep for 10 sec and try again.
-      sleep 10
+      sleep 5
       retry_count=$((retry_count-1))
       echo "unable to find test runner pod ....trying again"
       if [[ $retry_count -eq 0 ]]; then
         echo "unable to find test runner pod exiting"  # retry count is over.. pod is not found.. exit from while loop
         exit 1;
-      fi
-    else
-      echo "Litmus pod is $litmus_pod"  #if pod is found, print the litmus pod and exit from while loop 
-      break;
-    fi
+      fi 
+    fi   
   fi
 done
     

--- a/Openshift-EE/utils/litmus_job_runner
+++ b/Openshift-EE/utils/litmus_job_runner
@@ -22,9 +22,27 @@ bash ../Openshift-EE/utils/error_handler ${retcode} msg="Unable to run litmusboo
 ## Obtain the litmus pod name 
 
 litmusPodCmd="kubectl get pod --no-headers -n litmus -o jsonpath='{.items[?(@.metadata.labels.job-name==\"${job_name}\")].metadata.name}'"
-litmus_pod=$(eval ${litmusPodCmd}); retcode=$?
-bash ../Openshift-EE/utils/error_handler ${retcode} msg="Unable to find litmus test runner pod, exiting" action="exit"
 
+# Loop till you get the running litmus pod. If not able to find the pod, print error message
+let retry_count=7   # number of times you want to try again to get the name of litmus pod
+while true; do
+  litmus_pod=$(eval ${litmusPodCmd}); rc=$?
+  if [[ $rc -eq 0 ]]; then
+    if [[ -z ${litmus_pod} ]]; then   # if pod is not found it returns null. If pod name is not got sleep for 10 sec and try again.
+      sleep 10
+      retry_count=$((retry_count-1))
+      echo "unable to find test runner pod ....trying again"
+      if [[ $retry_count -eq 0 ]]; then
+        echo "unable to find test runner pod exiting"  # retry count is over.. pod is not found.. exit from while loop
+        exit 1;
+      fi
+    else
+      echo $litmus_pod  #if pod is found, print the litmus pod and exit from while loop 
+      break;
+    fi
+  fi
+done
+    
 ## Wait till the ansibletest container terminates && also confirm job completion status. This is done to ensure
 ## that execution of auxiliary containers such as loggers is completed. Getting the ansibletest ccontainer to completed state 
 ## satisfies the "necessary" condition for test job completion

--- a/Openshift-EE/utils/litmus_job_runner
+++ b/Openshift-EE/utils/litmus_job_runner
@@ -42,7 +42,6 @@ while true; do
   fi
 done
 
-
 ## Wait till the ansibletest container terminates && also confirm job completion status. This is done to ensure
 ## that execution of auxiliary containers such as loggers is completed. Getting the ansibletest ccontainer to completed state 
 ## satisfies the "necessary" condition for test job completion

--- a/Openshift-EE/utils/litmus_job_runner
+++ b/Openshift-EE/utils/litmus_job_runner
@@ -23,24 +23,19 @@ bash ../Openshift-EE/utils/error_handler ${retcode} msg="Unable to run litmusboo
 
 litmusPodCmd="kubectl get pod --no-headers -n litmus -o jsonpath='{.items[?(@.metadata.labels.job-name==\"${job_name}\")].metadata.name}'"
 
-# Loop till running litmus pod is got. If not able to find the pod, print error message
-# number of times we want to try again to get the name of litmus pod
 let retry_count=7  
 
 while true; do
   litmus_pod=$(eval ${litmusPodCmd}); rc=$?
-  if [[ $rc -eq 0 ]]; then
-    # if pod is not found it returns null. If pod name is not got sleep for 5 sec and try again.
+  if [[ $rc -eq 0 ]]; then  
     if [[ -z ${litmus_pod} ]]; then   
       sleep 5
       retry_count=$((retry_count-1))
       echo "unable to get litmus pod name....trying again"
       if [[ $retry_count -eq 0 ]]; then
-        # retry count is over.. pod is not found.. exit from while loop by printing error message.
         echo "unable to get litmus pod name exiting"  
         exit 1;
       fi
-    # if pod is found,exit from while loop
     else      
       break;
     fi

--- a/Openshift-EE/utils/litmus_job_runner
+++ b/Openshift-EE/utils/litmus_job_runner
@@ -23,12 +23,12 @@ bash ../Openshift-EE/utils/error_handler ${retcode} msg="Unable to run litmusboo
 
 litmusPodCmd="kubectl get pod --no-headers -n litmus -o jsonpath='{.items[?(@.metadata.labels.job-name==\"${job_name}\")].metadata.name}'"
 
-# Loop till you get the running litmus pod. If not able to find the pod, print error message
-let retry_count=7   # number of times you want to try again to get the name of litmus pod
+# Loop till the running litmus pod is got. If not able to find the pod, print error message
+let retry_count=7   # number of times we want to try again to get the name of litmus pod
 while true; do
   litmus_pod=$(eval ${litmusPodCmd}); rc=$?
   if [[ $rc -eq 0 ]]; then
-    if [[ -z ${litmus_pod} ]]; then   # if pod is not found it returns null. If pod name is not got sleep for 10 sec and try again.
+    if [[ -z ${litmus_pod} ]]; then   # if pod is not found it returns null. If pod name is not got sleep for 5 sec and try again.
       sleep 5
       retry_count=$((retry_count-1))
       echo "unable to find test runner pod ....trying again"

--- a/Openshift-EE/utils/litmus_job_runner
+++ b/Openshift-EE/utils/litmus_job_runner
@@ -23,23 +23,14 @@ bash ../Openshift-EE/utils/error_handler ${retcode} msg="Unable to run litmusboo
 
 litmusPodCmd="kubectl get pod --no-headers -n litmus -o jsonpath='{.items[?(@.metadata.labels.job-name==\"${job_name}\")].metadata.name}'"
 
-# Loop till the running litmus pod is got. If not able to find the pod, print error message
-let retry_count=7   # number of times we want to try again to get the name of litmus pod
-while true; do
+while true; do 
   litmus_pod=$(eval ${litmusPodCmd}); rc=$?
-  if [[ $rc -eq 0 ]]; then
-    if [[ -z ${litmus_pod} ]]; then   # if pod is not found it returns null. If pod name is not got sleep for 5 sec and try again.
-      sleep 5
-      retry_count=$((retry_count-1))
-      echo "unable to find test runner pod ....trying again"
-      if [[ $retry_count -eq 0 ]]; then
-        echo "unable to find test runner pod exiting"  # retry count is over.. pod is not found.. exit from while loop
-        exit 1;
-      fi 
-    fi   
+  if [[ $rc -eq 0 && -z ${litmus_pod} ]]; then  # if pod is not found it returns null. If pod name is not got sleep for 5 sec and try again.
+    sleep 5                           
+  else break;   # if you get the pod name exit from while loop
   fi
 done
-    
+
 ## Wait till the ansibletest container terminates && also confirm job completion status. This is done to ensure
 ## that execution of auxiliary containers such as loggers is completed. Getting the ansibletest ccontainer to completed state 
 ## satisfies the "necessary" condition for test job completion

--- a/Openshift-EE/utils/litmus_job_runner
+++ b/Openshift-EE/utils/litmus_job_runner
@@ -30,7 +30,7 @@ let retry_count=7
 while true; do
   litmus_pod=$(eval ${litmusPodCmd}); rc=$?
   if [[ $rc -eq 0 ]]; then
-    # if pod is not found it returns null. If pod name is not got sleep for 5 sec sec and try again.
+    # if pod is not found it returns null. If pod name is not got sleep for 5 sec and try again.
     if [[ -z ${litmus_pod} ]]; then   
       sleep 5
       retry_count=$((retry_count-1))

--- a/Openshift-EE/utils/litmus_job_runner
+++ b/Openshift-EE/utils/litmus_job_runner
@@ -23,13 +23,30 @@ bash ../Openshift-EE/utils/error_handler ${retcode} msg="Unable to run litmusboo
 
 litmusPodCmd="kubectl get pod --no-headers -n litmus -o jsonpath='{.items[?(@.metadata.labels.job-name==\"${job_name}\")].metadata.name}'"
 
-while true; do 
+# Loop till running litmus pod is got. If not able to find the pod, print error message
+# number of times we want to try again to get the name of litmus pod
+let retry_count=7  
+
+while true; do
   litmus_pod=$(eval ${litmusPodCmd}); rc=$?
-  if [[ $rc -eq 0 && -z ${litmus_pod} ]]; then  # if pod is not found it returns null. If pod name is not got sleep for 5 sec and try again.
-    sleep 5                           
-  else break;   # if you get the pod name exit from while loop
+  if [[ $rc -eq 0 ]]; then
+    # if pod is not found it returns null. If pod name is not got sleep for 5 sec sec and try again.
+    if [[ -z ${litmus_pod} ]]; then   
+      sleep 5
+      retry_count=$((retry_count-1))
+      echo "unable to get litmus pod name....trying again"
+      if [[ $retry_count -eq 0 ]]; then
+        # retry count is over.. pod is not found.. exit from while loop by printing error message.
+        echo "unable to get litmus pod name exiting"  
+        exit 1;
+      fi
+    # if pod is found,exit from while loop
+    else      
+      break;
+    fi
   fi
 done
+
 
 ## Wait till the ansibletest container terminates && also confirm job completion status. This is done to ensure
 ## that execution of auxiliary containers such as loggers is completed. Getting the ansibletest ccontainer to completed state 

--- a/Openshift-EE/utils/litmus_job_runner
+++ b/Openshift-EE/utils/litmus_job_runner
@@ -37,7 +37,7 @@ while true; do
         exit 1;
       fi
     else
-      echo $litmus_pod  #if pod is found, print the litmus pod and exit from while loop 
+      echo "Litmus pod is $litmus_pod"  #if pod is found, print the litmus pod and exit from while loop 
       break;
     fi
   fi


### PR DESCRIPTION
* The script is modified to get the name of litmus pod and if pod is not found, it tries again till retry_count 
  becomes zero.
* The following script is modified:
      utils/litmus_job_runner

The bash script is tested in Openshift cluster manually by editing litmus job name.
* If the litmus job name is correct, then pod name is found and  the program exits from while loop
```
[root@master-1554817485 deployers]# ./test1.sh

```
* If the job name is wrong, then pod name is not found and the script tries again to get the name till 
  retry_count becomes 0. Finally exits from while loop by printing appropriate error message.
```
[root@master-1554817485 deployers]# ./test.sh
unable to get litmus pod name....trying again
unable to get litmus pod name....trying again
unable to get litmus pod name....trying again
unable to get litmus pod name....trying again
unable to get litmus pod name....trying again
unable to get litmus pod name....trying again
unable to get litmus pod name....trying again
unable to get litmus pod name exiting

```  

