### PR TITLE
Changed job order to run some jobs serially

### DIFF
--- a/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/340W-snap-rebuild-single-rep/snap-rebuild-single-rep
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/340W-snap-rebuild-single-rep/snap-rebuild-single-rep
@@ -24,6 +24,8 @@ bash Openshift-EE/utils/e2e-cr jobname:snap-rebuild-single-rep jobphase:Waiting
 bash Openshift-EE/utils/e2e-cr jobname:snap-rebuild-single-rep jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 bash Openshift-EE/utils/e2e-cr jobname:snap-rebuild-multiple-rep jobphase:Waiting
 bash Openshift-EE/utils/e2e-cr jobname:clone-post-snap-rebuild jobphase:Waiting
+bash Openshift-EE/utils/e2e-cr jobname:pool-delete jobphase:Waiting
+bash Openshift-EE/utils/e2e-cr jobname:pool-kill jobphase:Waiting
 
 ################
 # LitmusBook 1 #

--- a/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/72WM-cstor-pool-delete/cstor-pool-delete
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/72WM-cstor-pool-delete/cstor-pool-delete
@@ -20,9 +20,8 @@ current_time=$(eval $time)
 present_dir=$(pwd)
 echo $present_dir
 
-bash Openshift-EE/utils/e2e-cr jobname:pool-delete jobphase:Waiting init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
-bash Openshift-EE/utils/e2e-cr jobname:pool-delete jobphase:Running init_time:"$current_time"
-bash Openshift-EE/utils/e2e-cr jobname:pool-kill jobphase:Waiting
+bash Openshift-EE/utils/pooling jobname:clone-post-snap-rebuild
+bash Openshift-EE/utils/e2e-cr jobname:pool-delete jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
 ################
 # LitmusBook 1 #

--- a/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/QURH-clone-post-snap-rebuild/clone-post-rebuild
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/QURH-clone-post-snap-rebuild/clone-post-rebuild
@@ -134,6 +134,10 @@ exit 1;
 fi
 
 current_time=$(eval $time)
+
+# Update the e2e cr once the job is completed
+bash Openshift-EE/utils/e2e-cr jobname:clone-post-snap-rebuild jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:$testResult
+
 python3 Openshift-EE/utils/result/result_update.py $job_id $case_id 4-chaos "Check if the clone can be created after snapshot rebuilt successfully" Pass $pipeline_id "$current_time" $commit_id $gittoken
 
 if [ "$rc_val" != "0" ]; then


### PR DESCRIPTION
Updated gitlab scripts to run the gitlab jobs in following order:
 - jobname:snap-rebuild-single-rep
 - jobname:snap-rebuild-multiple-rep
 - jobname:clone-post-snap-rebuild j
 - jobname:pool-delete 
 - jobname:pool-kill 
This change is required to avoid the jobs affecting each other while  running.




@nsathyaseelan 