### PR TITLE
[skip ci]Case id is changed in gitlab-ci.yml for bash scripts 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,21 +36,21 @@ HC5P-STRIPED-POOL:
     - chmod 775 ./Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/HC5P-create-striped-pool/create-striped-pool
     - ./Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/HC5P-create-striped-pool/create-striped-pool
 
-HC5P-MIRRORED-POOL:
+G45J-MIRRORED-POOL:
   image: openebs/openshift-ci:latest
   stage: OPENEBS-SETUP
   script:
     - chmod 775 ./Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/G45J-create-mirrored-pool/create-mirrored-pool
     - ./Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/G45J-create-mirrored-pool/create-mirrored-pool
 
-HC5P-RAIDZ1-POOL:
+37Y6-RAIDZ1-POOL:
   image: openebs/openshift-ci:latest
   stage: OPENEBS-SETUP
   script:
     - chmod 775 ./Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/37Y6-create-raidz1-pool/create-raidz1-pool
     - ./Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/37Y6-create-raidz1-pool/create-raidz1-pool
 
-HC5P-RAIDZ2-POOL:
+9ZWW-RAIDZ2-POOL:
   image: openebs/openshift-ci:latest
   stage: OPENEBS-SETUP
   script:

--- a/Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/1CXH-storage-policies/openebs-sc
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/1CXH-storage-policies/openebs-sc
@@ -20,7 +20,7 @@ echo $present_dir
 
 #pooling over previous job to complete
 echo "***********Applying openebs-storage-clas********"
-bash Openshift-EE/utils/pooling jobname:s2-j2-cstor-pool
+bash Openshift-EE/utils/pooling jobname:s2-j5-cstor-raidz2-pool
 bash Openshift-EE/utils/e2e-cr jobname:s2-j3-policies jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
 test_name=$(bash Openshift-EE/utils/generate_test_name testcase=cstor-storage-policies metadata="")

--- a/Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/1CXH-storage-policies/openebs-sc
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/1CXH-storage-policies/openebs-sc
@@ -21,7 +21,7 @@ echo $present_dir
 #pooling over previous job to complete
 echo "***********Applying openebs-storage-clas********"
 bash Openshift-EE/utils/pooling jobname:s2-j5-cstor-raidz2-pool
-bash Openshift-EE/utils/e2e-cr jobname:s2-j3-policies jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+bash Openshift-EE/utils/e2e-cr jobname:s2-j6-policies jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
 test_name=$(bash Openshift-EE/utils/generate_test_name testcase=cstor-storage-policies metadata="")
 echo $test_name
@@ -40,7 +40,7 @@ echo "Dumping state of cluster post job run"; echo ""
 bash ../Openshift-EE/utils/dump_cluster_state;
 
 cd ..
-bash Openshift-EE/utils/event_updater jobname:s2-j3-policies $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+bash Openshift-EE/utils/event_updater jobname:s2-j6-policies $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 #################
 ## GET RESULT  ##
 #################
@@ -53,7 +53,7 @@ testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-column
 #python3 Openshift-EE/utils/result/result_update.py $job_id 1CXH 2-setup "Create K8s storage classes adhering the policies supported by OpenEBS" $testResult $pipeline_id "$current_time" $commit_id $gittoken
 
 current_time=$(eval $time)
-bash Openshift-EE/utils/e2e-cr jobname:s2-j3-policies jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Pass 
+bash Openshift-EE/utils/e2e-cr jobname:s2-j6-policies jobphase:Completed end_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" test_result:Pass 
 
 python3 Openshift-EE/utils/result/result_update.py $job_id 1CXH 2-setup "Create K8s storage classes adhering the policies supported by OpenEBS" $testResult $pipeline_id "$current_time" $commit_id $gittoken
 

--- a/Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/HC5P-create-striped-pool/create-striped-pool
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/HC5P-create-striped-pool/create-striped-pool
@@ -42,15 +42,13 @@ echo "Running the litmus test.."
  | Litmus Job name   | name   | generateName: cstor-block-device-pool-provision | generateName: cstor-block-device-striped-pool-provision      |
  | ImagePullPolicy   | value  | Always                                          | IfNotPresent                                                 |
  | Pool name         | name   | cstor-block-disk-pool                           | cstor-block-disk-pool-stripe                                 |
- | storage class     | env    | openebs-cstor-disk                              | openebs-cstor-stripe                                         |
-   ---------------------------------------------------------------------------------------------------------------------------------------------
+ ---------------------------------------------------------------------------------------------------------------------------------------------
 EOF
 
 sed -i -e 's/app: cstor-block-device-pool-provision/app: cstor-striped-pool-provision/g' \
 -e 's/generateName: cstor-block-device-pool-provision/generateName: cstor-block-device-striped-pool-provision/g' \
 -e 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' \
--e 's/value: cstor-block-disk-pool/value: cstor-block-disk-pool-stripe/g' \
--e 's/value: openebs-cstor-disk/value: openebs-cstor-stripe/g' create_striped_pool.yml
+-e 's/value: cstor-block-disk-pool/value: cstor-block-disk-pool-stripe/g' create_striped_pool.yml
 
 sed -i '/command:/i \
           - name: RUN_ID\

--- a/Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/K9YC-openebs-deploy/deploy-openebs
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/K9YC-openebs-deploy/deploy-openebs
@@ -42,7 +42,7 @@ bash Openshift-EE/utils/e2e-cr jobname:bdd-jiva-clone jobphase:Waiting
 bash Openshift-EE/utils/e2e-cr jobname:bdd-cstor-volume-clone-provisioning jobphase:Waiting
 bash Openshift-EE/utils/e2e-cr jobname:bdd-cstor-snapshot-provisioning jobphase:Waiting
 bash Openshift-EE/utils/e2e-cr jobname:bdd-cstor-volume-provisioning jobphase:Waiting
-bash Openshift-EE/utils/e2e-cr jobname:s2-j3-policies jobphase:Waiting 
+bash Openshift-EE/utils/e2e-cr jobname:s2-j6-policies jobphase:Waiting 
 bash Openshift-EE/utils/e2e-cr jobname:s2-j2-cstor-striped-pool jobphase:Waiting 
 bash Openshift-EE/utils/e2e-cr jobname:s2-j3-cstor-mirrored-pool jobphase:Waiting
 bash Openshift-EE/utils/e2e-cr jobname:s2-j4-cstor-raidz1-pool jobphase:Waiting


### PR DESCRIPTION
* The case id is changed in gitlab-ci.yml
* The correct ids are provided. 
* Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/1CXH-storage-policies/openebs-sc  is executed at end in 2-setup stage.
* Storage class name remains the same as in run_litmus_test. sed operation is removed.