### PR TITLE
[skip ci]Changed the cstor pool name for the creation of storage classes

### DIFF
--- a/Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/1CXH-storage-policies/openebs-sc
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/1CXH-storage-policies/openebs-sc
@@ -29,7 +29,7 @@ echo $test_name
 cd litmus
 echo "Running the litmus test.."
 sed -i -e 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' \
--e 's/cstor-sparse-pool/cstor-block-disk-pool/g' providers/cstor-storage-policies/run_litmus_test.yml
+-e 's/cstor-sparse-pool/cstor-block-disk-pool-stripe/g' providers/cstor-storage-policies/run_litmus_test.yml
 run_test=providers/cstor-storage-policies/run_litmus_test.yml
 
 cat $run_test

--- a/Openshift-EE/pipelines/OpenEBS-base/stages/5-infra-chaos/Z0KY-Fill-node/fill-node-capacity
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/5-infra-chaos/Z0KY-Fill-node/fill-node-capacity
@@ -43,7 +43,7 @@ cp experiments/chaos/node_storage_fill/run_litmus_test.yml fill_capacity.yml
 
 sed -i -e 's/app-busybox-ns/fill-node-capacity/g' \
 -e 's/openebs-cstor-sparse/openebs-cstor-disk/g' \
--e 's/cstor-sparse-pool/cstor-block-disk-pool/g' fill_capacity.yml
+-e 's/cstor-sparse-pool/cstor-block-disk-pool-stripe/g' fill_capacity.yml
 
 sed -i -e "s|#nodeSelector|nodeSelector|g" \
 -e "s|#  kubernetes.io/hostname:|  kubernetes.io/hostname: ${observer_node}|g" fill_capacity.yml


### PR DESCRIPTION
* The cstor pool name is changed in scripts.
* The storage class used striped pool.
* Following files are changed:
        modified:   2-setup/1CXH-storage-policies/openebs-sc
	modified:   5-infra-chaos/Z0KY-Fill-node/fill-node-capacity 