### PR TITLE
Changed result table existance condition

### DIFF
--- a/Openshift-EE/utils/result/result_update.py
+++ b/Openshift-EE/utils/result/result_update.py
@@ -96,22 +96,26 @@ def fetch_file_content():
     file_content=str(file.decoded_content)
     file_content=str(file.decoded_content, 'utf-8')
     content_list = file_content.split('\n')
-
-    # updating result's table if the table is already there
-    if file_content.find('|')>0:
-        new_job = '|     {}           |  {}           | {}  | {} |'.format(job_url,test_desc,time_stamp ,efk_link)
-        index = content_list.index('| Job ID |   Test Description         | Execution Time |Test Result   |')
-        content_list.insert(index+2,new_job)
-        updated_file_content = ('\n').join(content_list)
-        
-    # creating result's table for first job result entry 
-    else:
+    content_list_nospace = file_content.split('\r\n')
+    content_list_nospace = list(filter(lambda x: x != '', content_list))
+    last_line = content_list_nospace[-1].lower()
+    
+    # creating result's table for first job result entry by checking if the last line of the Readme.md has `Test Result` or not
+    if 'test result' in last_line:
         updated_file_content =  '| Job ID |   Test Description         | Execution Time |Test Result   |\n'
         updated_file_content = updated_file_content + (' |---------|---------------------------| --------------|--------|\n')
         updated_file_content = updated_file_content + (' |    {}   |  {}           |  {}     |{}  |\n'.format(job_url, test_desc, time_stamp, efk_link))
         index = len(content_list)
         content_list.insert(index, updated_file_content)
         updated_file_content = ('\n').join(content_list)
+
+     # updating result's table if the table is already there
+    else:
+        new_job = '|     {}           |  {}           | {}  | {} |'.format(job_url,test_desc,time_stamp ,efk_link)
+        index = content_list.index('| Job ID |   Test Description         | Execution Time |Test Result   |')
+        content_list.insert(index+2,new_job)
+        updated_file_content = ('\n').join(content_list)
+
     return file, updated_file_content
     
 # github commit message 
@@ -159,4 +163,3 @@ except github.GithubException as e:
      else:
        print("Readme.md updation failed")
        break
-


### PR DESCRIPTION
Changed the condition of checking if the 'Result Table' exists in the Readme.md or not
Earlier script was checking the existence of '|' and if it is not there it was concluding that the table is not there. We used this condition because 'Result Table' consists of this character.
This condition will not work as expected if the Readme.md file contains  '|'  in its content
This PR will solve this issue, as now script is checking the existence of 'Test Result' in the last line of the file content, if it's there it will conclude that the table is not there



@gprasath @nsathyaseelan 