### PR TITLE
feat[script]: Included jiva internal snapshot delete job in OpenEBS-base branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -167,6 +167,12 @@ ZK9B-cStor-Create-Clone:
     - chmod 775 ./Openshift-EE/pipelines/OpenEBS-base/stages/3-functional/6RQL-Clone-different-capacity/clone-different-capacity
     - ./Openshift-EE/pipelines/OpenEBS-base/stages/3-functional/6RQL-Clone-different-capacity/clone-different-capacity
 
+8QQP-Jiva-Snapshot-Delete:
+  extends: .func_test_template
+  script:
+    - chmod 775 ./Openshift-EE/pipelines/OpenEBS-base/stages/3-functional/8QQP-Jiva-Snapshot-Delete/jiva-snapshot-delete
+    - ./Openshift-EE/pipelines/OpenEBS-base/stages/3-functional/8QQP-Jiva-Snapshot-Delete/jiva-snapshot-delete
+
 5O5V-cStor-Parent-Volume-Delete:
   extends: .func_test_template
   script: 

--- a/Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/1CXH-storage-policies/openebs-sc
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/2-setup/1CXH-storage-policies/openebs-sc
@@ -20,7 +20,7 @@ echo $present_dir
 
 #pooling over previous job to complete
 echo "***********Applying openebs-storage-clas********"
-bash Openshift-EE/utils/pooling jobname:s2-j5-cstor-raidz2-pool
+bash Openshift-EE/utils/pooling jobname:cstor-cspc-striped-pool
 bash Openshift-EE/utils/e2e-cr jobname:s2-j6-policies jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
 
 test_name=$(bash Openshift-EE/utils/generate_test_name testcase=cstor-storage-policies metadata="")

--- a/Openshift-EE/pipelines/OpenEBS-base/stages/3-functional/8QQP-Jiva-Snapshot-Delete/jiva-snapshot-delete
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/3-functional/8QQP-Jiva-Snapshot-Delete/jiva-snapshot-delete
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -x
+
+pod() {
+# sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'git clone -b OpenEBS-base https://github.com/openebs/e2e-openshift.git'
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-openshift && bash Openshift-EE/pipelines/OpenEBS-base/stages/3-functional/8QQP-Jiva-Snapshot-Delete/jiva-snapshot-delete node '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"'
+}
+
+node() {
+job_id=$(echo $1)
+pipeline_id=$(echo $2)
+commit_id=$(echo $3)
+case_id=8QQP
+
+source ~/.profile
+gittoken=$(echo "$github_token")
+
+time="date"
+current_time=$(eval $time)
+
+present_dir=$(pwd)
+echo $present_dir
+
+bash Openshift-EE/utils/e2e-cr jobname:jiva-internal-snapshot-deletion jobphase:Waiting
+bash Openshift-EE/utils/e2e-cr jobname:jiva-internal-snapshot-deletion jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+################
+# LitmusBook 1 #
+################
+
+: << EOF
+  --------------------------------------------------------------------------------------------------------------------     
+ | specAttribute     | kind   |         default value               | test specifc value                              |
+  ------------------------------------------------------------------------------------------------------------------- |
+ | storage clas      | env    | openebs-jiva-standard               | openebs-jiva-default                            |
+ | appNamespace      | env    | fio                                 | fio-jiva-snapshot-del                           |
+  ---------------------------------------------------------------------------------------------------------------------
+EOF
+
+test_name=$(bash Openshift-EE/utils/generate_test_name testcase=fio-di-delete-jiva-snapshots metadata="")
+echo $test_name
+
+
+cd litmus
+echo "Running the litmus test for Jiva internal snapshot deletion."
+cp experiments/functional/snapshot_deletion/jiva/run_litmus_test.yml jiva_snapshot_delete.yml
+
+sed -i -e 's/value: fio/value: fio-jiva-snapshot-del/g' \
+-e 's/value: openebs-jiva-standard/value: openebs-jiva-default/g' jiva_snapshot_delete.yml
+
+cat jiva_snapshot_delete.yml
+
+bash ../Openshift-EE/utils/litmus_job_runner label='app:fio-di-litmus-snap-del' job=jiva_snapshot_delete.yml
+cd ..
+bash Openshift-EE/utils/dump_cluster_state;
+bash Openshift-EE/utils/event_updater jobname:jiva-internal-snapshot-deletion $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
+
+if [ "$?" != "0" ]; then
+python3 Openshift-EE/utils/result/result_update.py $job_id 8QQP 3-functional "Verify if the snapshot is getting Deleted Automatically" Fail $pipeline_id "$current_time" $commit_id $gittoken
+exit 1;
+fi
+
+}
+
+if [ "$1" == "node" ];then
+  node $2 $3 $4
+else
+  pod
+fi


### PR DESCRIPTION
1. Added a new job "Jiva-snapshot-delete" in functional stage.
2. Changed the pooling jobname to cstor-cspc-striped-pool in setup stage for storage policies job.
3. Update above changes in .gitlab-ci.yaml file.

Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>