### PR TITLE
refactor[yaml]: Enable data persistence in chaos job in release-branch

### DIFF
--- a/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/2HXA-cstor-volume-mgmt-kill/cstor-volume-mgmt-kill
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/2HXA-cstor-volume-mgmt-kill/cstor-volume-mgmt-kill
@@ -143,6 +143,16 @@ sed -i '/command:/i \
             value: '"$run_id"'\
 ' run_targetmgmt_kill_test.yml
 
+## Replace the value of DATA_PERSISTENCE with application name in litmus experiment. 
+sed -i '/name: DATA_PERSISTENCE/{n;s/.*/            value: busybox/}' run_targetmgmt_kill_test.yml
+
+## Insert the set of variables for busybox data consistency util into configmap spec.
+sed -i '/parameters.yml: |/a \
+    blocksize: 4k\
+    blockcount: 1024\
+    testfile: targetmgmtkilltest
+' run_targetmgmt_kill_test.yml
+
 # Running the litmus test for Busybox Deployment Scaleup
 cat run_targetmgmt_kill_test.yml
 

--- a/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/2HXA-cstor-volume-mgmt-kill/cstor-volume-mgmt-kill
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/2HXA-cstor-volume-mgmt-kill/cstor-volume-mgmt-kill
@@ -130,33 +130,33 @@ run_id="mgmt";test_name=$(bash Openshift-EE/utils/generate_test_name testcase=op
 echo $test_name
 
 cd litmus
-cp experiments/chaos/openebs_target_failure/run_litmus_test.yml run_targetmgmt_kill_test.yml
+cp experiments/chaos/openebs_target_failure/run_litmus_test.yml run_target_mgmt_kill_test.yml
 
 sed -i -e 's/value: percona-mysql-claim/value: openebs-bb-mgmt-targetkill/g' \
 -e 's/name: target-failure/name: target-mgmt-kill/g' \
 -e 's/name: openebs-target-failure/name: openebs-target-mgmt-failure/g' \
 -e 's/value: '\''name=percona'\''/value: '\''app=target-mgmt-kill'\''/g' \
--e 's/value: app-percona-ns/value: mgmt-kill/g' run_targetmgmt_kill_test.yml
+-e 's/value: app-percona-ns/value: mgmt-kill/g' run_target_mgmt_kill_test.yml
 
 sed -i '/command:/i \
           - name: RUN_ID\
             value: '"$run_id"'\
-' run_targetmgmt_kill_test.yml
+' run_target_mgmt_kill_test.yml
 
 ## Replace the value of DATA_PERSISTENCE with application name in litmus experiment. 
-sed -i '/name: DATA_PERSISTENCE/{n;s/.*/            value: busybox/}' run_targetmgmt_kill_test.yml
+sed -i '/name: DATA_PERSISTENCE/{n;s/.*/            value: busybox/}' run_target_mgmt_kill_test.yml
 
 ## Insert the set of variables for busybox data consistency util into configmap spec.
 sed -i '/parameters.yml: |/a \
     blocksize: 4k\
     blockcount: 1024\
     testfile: targetmgmtkilltest
-' run_targetmgmt_kill_test.yml
+' run_target_mgmt_kill_test.yml
 
 # Running the litmus test for Busybox Deployment Scaleup
-cat run_targetmgmt_kill_test.yml
+cat run_target_mgmt_kill_test.yml
 
-bash ../Openshift-EE/utils/litmus_job_runner label='name:openebs-target-mgmt-failure' job=run_targetmgmt_kill_test.yml
+bash ../Openshift-EE/utils/litmus_job_runner label='name:openebs-target-mgmt-failure' job=run_target_mgmt_kill_test.yml
 cd ..
 bash Openshift-EE/utils/dump_cluster_state;
 bash Openshift-EE/utils/event_updater jobname:target-mgmt-kill $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"

--- a/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/PG1D-cstor-volume-istgt-kill/cstor-volume-istgt-kill
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/PG1D-cstor-volume-istgt-kill/cstor-volume-istgt-kill
@@ -114,6 +114,7 @@ cd litmus
 cp experiments/chaos/openebs_target_failure/run_litmus_test.yml run_targetistgt_kill_test.yml
 
 sed -i -e 's/value: percona-mysql-claim/value: openebs-bb-istgt-targetkill/g' \
+-e 's/name: target-failure/name: target-istgt-kill/g' \
 -e 's/name: openebs-target-failure/name: openebs-target-istgt-failure/g' \
 -e 's/target-zrepl-kill/target-kill/g' \
 -e 's/cstor-volume-mgmt/cstor-istgt/g' \
@@ -124,6 +125,16 @@ sed -i -e 's/value: percona-mysql-claim/value: openebs-bb-istgt-targetkill/g' \
 sed -i '/command:/i \
           - name: RUN_ID\
             value: '"$run_id"'\
+' run_targetistgt_kill_test.yml
+
+## Replace the value of DATA_PERSISTENCE with application name in litmus experiment. 
+sed -i '/name: DATA_PERSISTENCE/{n;s/.*/            value: busybox/}' run_targetistgt_kill_test.yml
+
+## Insert the set of variables for busybox data consistency util into configmap spec.
+sed -i '/parameters.yml: |/a \
+    blocksize: 4k\
+    blockcount: 1024\
+    testfile: targetistgtkilltest
 ' run_targetistgt_kill_test.yml
 
 echo "Running the litmus test for Busybox Deployment Scaleup.."
@@ -203,7 +214,6 @@ cp apps/busybox/deployers/run_litmus_test.yml deprovision_target_istgt_kill.yml
 
 sed -i -e 's/generateName: litmus-busybox-deploy/generateName: busybox-deprovision-istgt-kill/g' \
 -e 's/app: busybox-litmus/app: busybox-deprovision-istgt-kill/g' \
--e 's/name: target-failure/name: target-istgt-kill/g' \
 -e 's/app=busybox-sts/app=istgt-kill/g' \
 -e 's/value: statefulset/value: deployment/g' \
 -e 's/value: openebs-cstor-sparse/value: openebs-cstor-disk/g' \

--- a/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/PG1D-cstor-volume-istgt-kill/cstor-volume-istgt-kill
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/PG1D-cstor-volume-istgt-kill/cstor-volume-istgt-kill
@@ -111,7 +111,7 @@ run_id="istgt";test_name=$(bash Openshift-EE/utils/generate_test_name testcase=o
 echo $test_name
 
 cd litmus
-cp experiments/chaos/openebs_target_failure/run_litmus_test.yml run_targetistgt_kill_test.yml
+cp experiments/chaos/openebs_target_failure/run_litmus_test.yml run_target_istgt_kill_test.yml
 
 sed -i -e 's/value: percona-mysql-claim/value: openebs-bb-istgt-targetkill/g' \
 -e 's/name: target-failure/name: target-istgt-kill/g' \
@@ -120,27 +120,27 @@ sed -i -e 's/value: percona-mysql-claim/value: openebs-bb-istgt-targetkill/g' \
 -e 's/cstor-volume-mgmt/cstor-istgt/g' \
 -e 's/value: openebs-cstor-sparse/value: openebs-cstor-disk/g' \
 -e 's/value: '\''name=percona'\''/value: '\''app=istgt-kill'\''/g' \
--e 's/value: app-percona-ns/value: istgt-kill/g' run_targetistgt_kill_test.yml
+-e 's/value: app-percona-ns/value: istgt-kill/g' run_target_istgt_kill_test.yml
 
 sed -i '/command:/i \
           - name: RUN_ID\
             value: '"$run_id"'\
-' run_targetistgt_kill_test.yml
+' run_target_istgt_kill_test.yml
 
 ## Replace the value of DATA_PERSISTENCE with application name in litmus experiment. 
-sed -i '/name: DATA_PERSISTENCE/{n;s/.*/            value: busybox/}' run_targetistgt_kill_test.yml
+sed -i '/name: DATA_PERSISTENCE/{n;s/.*/            value: busybox/}' run_target_istgt_kill_test.yml
 
 ## Insert the set of variables for busybox data consistency util into configmap spec.
 sed -i '/parameters.yml: |/a \
     blocksize: 4k\
     blockcount: 1024\
     testfile: targetistgtkilltest
-' run_targetistgt_kill_test.yml
+' run_target_istgt_kill_test.yml
 
 echo "Running the litmus test for Busybox Deployment Scaleup.."
-cat run_targetistgt_kill_test.yml
+cat run_target_istgt_kill_test.yml
 
-bash ../Openshift-EE/utils/litmus_job_runner label='name:openebs-target-istgt-failure' job=run_targetistgt_kill_test.yml
+bash ../Openshift-EE/utils/litmus_job_runner label='name:openebs-target-istgt-failure' job=run_target_istgt_kill_test.yml
 cd ..
 bash Openshift-EE/utils/dump_cluster_state;
 bash Openshift-EE/utils/event_updater jobname:target-istgt-kill $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

1. Data persistence is enabled against busybox application in two chaos jobs.
   

- cstor-Volume-mgmt-kill

- cstor-Volume-istgt-kill