### PR TITLE
[skip ci]: Enabled data persistence in app-kill test in OpenEBS-base branch

### DIFF
--- a/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/1PP5-app-kill/app-kill
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/1PP5-app-kill/app-kill
@@ -135,7 +135,18 @@ cd litmus
 cp experiments/chaos/app_pod_failure/run_litmus_test.yml appkill.yml
 
 sed -i -e 's/app=jenkins-app/app=app-kill/g' \
+-e 's/name: app-failure/name: app-kill/g' \
 -e 's/value: app-jenkins-ns/value: app-kill/g' appkill.yml
+
+## Replace the value of DATA_PERSISTENCE with application name in litmus experiment. 
+sed -i '/name: DATA_PERSISTENCE/{n;s/.*/            value: busybox/}' appkill.yml
+
+## Insert the set of variables for busybox data consistency util into configmap spec.
+sed -i '/parameters.yml: |/a \
+    blocksize: 4k\
+    blockcount: 1024\
+    testfile: appkill
+' appkill.yml
 
 echo "Running the litmus test for Busybox Deployment application pod kill.."
 cat appkill.yml

--- a/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/AUZF-Jiva-app-kill/jiva-app-kill
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/AUZF-Jiva-app-kill/jiva-app-kill
@@ -142,11 +142,22 @@ EOF
 sed -i -e 's/value: '\''app=jenkins-app'\''/value: '\''app=bb-app-kill-jiva'\''/g' \
 -e 's/generateName: application-pod-failure/generateName: application-pod-failure-jiva/g' \
 -e 's/name: application-pod-failure/name: application-pod-failure-jiva/g' \
+-e 's/name: app-failure/name: jiva-app-failure/g' \
 -e 's/value: app-jenkins-ns/value: app-kill-jiva/g' app_kill_jiva.yml
 
 sed -i '/command:/i \
           - name: RUN_ID\
             value: '"$run_id"'\
+' app_kill_jiva.yml
+
+## Replace the value of DATA_PERSISTENCE with application name in litmus experiment. 
+sed -i '/name: DATA_PERSISTENCE/{n;s/.*/            value: busybox/}' app_kill_jiva.yml
+
+## Insert the set of variables for busybox data consistency util into configmap spec.
+sed -i '/parameters.yml: |/a \
+    blocksize: 4k\
+    blockcount: 1024\
+    testfile: jivaappkill
 ' app_kill_jiva.yml
 
 cat app_kill_jiva.yml


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

1. Data persistence against busybox application is enabled in following chaos jobs.

- app-kill
- jiva-app-kill