### PR TITLE
[skip ci]: Modified the cluster-check job in openshift release branch to check no of ready nodes

### DIFF
--- a/Openshift-EE/pipelines/OpenEBS-base/stages/1-cluster-setup/PCZD-cluster-setup/cluster-state
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/1-cluster-setup/PCZD-cluster-setup/cluster-state
@@ -23,7 +23,7 @@ fi
 echo "*************************Checking the Cluster's Health********************"
 
 echo "Checking for the number of nodes in ready state*******************************"
-ready_nodes=$(sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port kubectl get nodes | grep Ready | wc -l)
+ready_nodes=$(sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port kubectl get nodes --no-headers | grep -v NotReady | wc -l)
 
 git_token=$(sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cat ~/.profile | grep github_token | cut -d= -f2')
 gittoken=$(echo $git_token | tr -d '"')


### PR DESCRIPTION
command `kubectl get no | grep Ready | wc -l ` will also include the nodes which are NotReady as `Ready` is itself a substring for `NotReady`. 
so we can use filter with NotReady state like this:
`kubectl get nodes --no-headers | grep -v NotReady | wc -l` This will include only nodes which are not `NotReady` means `Ready`

Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>