### PR TITLE
fix[script]: Included a pooling logic in cstor target failure when cvr scaleup test script

### DIFF
--- a/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/340W-snap-rebuild-single-rep/snap-rebuild-single-rep
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/340W-snap-rebuild-single-rep/snap-rebuild-single-rep
@@ -27,6 +27,7 @@ bash Openshift-EE/utils/e2e-cr jobname:snap-rebuild-multiple-rep jobphase:Waitin
 bash Openshift-EE/utils/e2e-cr jobname:clone-post-snap-rebuild jobphase:Waiting
 bash Openshift-EE/utils/e2e-cr jobname:pool-delete jobphase:Waiting
 bash Openshift-EE/utils/e2e-cr jobname:pool-kill jobphase:Waiting
+bash Openshift-EE/utils/e2e-cr jobname:target-failure-cvr-scaleup jobphase:Waiting
 
 ################
 # LitmusBook 1 #

--- a/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/NQ82-cStor-target-failure-new-replica-rebuild/target-failure-new-replica-rebuild
+++ b/Openshift-EE/pipelines/OpenEBS-base/stages/4-chaos/NQ82-cStor-target-failure-new-replica-rebuild/target-failure-new-replica-rebuild
@@ -20,7 +20,7 @@ current_time=$(eval $time)
 
 present_dir=$(pwd)
 echo $present_dir
-bash Openshift-EE/utils/e2e-cr jobname:target-failure-cvr-scaleup jobphase:Waiting
+bash Openshift-EE/utils/pooling jobname:pool-kill
 bash Openshift-EE/utils/e2e-cr jobname:target-failure-cvr-scaleup jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag"
 
 ################


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Included the pooling logic for cstor target failure when the replica scaeup is in progress test.